### PR TITLE
Preemptively convert double `p.value` to character

### DIFF
--- a/R/cogmapr-comp.R
+++ b/R/cogmapr-comp.R
@@ -184,6 +184,7 @@ RelationshipTest  <- function(project,
             dplyr::right_join(data.frame(edge = non.null.edges,
                                          stringsAsFactors=FALSE),
                               by = "edge") %>%
+            dplyr::mutate(p.value = as.character(p.value)) %>%
             tidyr::replace_na(list(p.value = "NR"))
     }
 


### PR DESCRIPTION
We are updating `tidyr::replace_na()` to utilize the vctrs package, and that results in slightly stricter / more correct type conversions. See https://github.com/tidyverse/tidyr/pull/1219

We noticed in revdeps that this package broke. An easy way to see this is by installing the PR mentioned above and running:

``` r
library(cogmapr)

project_name <- "a_new_project"
main_path <- paste0(system.file("testdata", package = "cogmapr"), '/')
my.project <- ProjectCMap(main_path, project_name)

## need more documents
RelationshipTest(my.project, units = c("Belgium", "Québec"))
#> Error: Can't convert `replace$p.value` <character> to match type of `data$p.value` <double>.
```

<sup>Created on 2021-11-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

The problem boils down to the fact that you are calling `replace_na(<dbl>, replace = "NR")`. In other words, you are trying to replace missing values in a _double_ column with a _character_ `"NR"` value. This is no longer allowed.

I've updated your code to preemptively call `as.character()` on the `p.value` column, since it seems like you wanted it to be a character column. This should work with both the CRAN and dev versions of tidyr, so you can go ahead and send a patch release of your package to CRAN.

We would greatly appreciate if you could merge this PR and submit a patch release of your package to CRAN so we can send tidyr in!